### PR TITLE
Use new kernel module location for Debian 12+

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -332,7 +332,13 @@ tar pcJf ../rootfs.tar.xz ./*
 	cp /kernel_usb.bin xe303c12/kernel_usb.bin
 	mv /kernel_emmc_ext4.bin xe303c12/kernel_emmc_ext4.bin
 	mv rootfs.tar.xz xe303c12/rootfs.tar.xz
-	cp ../scripts/install.sh xe303c12/install.sh
+	if [ "$VERSION_CODENAME" == "bullseye" ]; then
+		# usrmerge has not moved the kernel modules to /usr/lib/modules yet
+        sed -Ee 's`(\s/?)usr/lib([\s/])`\1lib\2`' ../scripts/install.sh > xe303c12/install.sh
+		chmod +x xe303c12/install.sh
+	else
+		cp ../scripts/install.sh xe303c12/install.sh
+	fi
 	cat <<'EOF' >xe303c12/xfce_install.sh
 #!/bin/bash
 # Install packages

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,7 +137,7 @@ else
 		if [ "$sure" != "yes" ]; then
 			stop "Stopped by the user"
 		fi
-		tar xJf rootfs.tar.xz -C / usr/lib/modules/
+		tar xJf rootfs.tar.xz -C / ./usr/lib/modules/
 		dd if=kernel_emmc_ext4.bin of=/dev/mmcblk0p1
 	else
 		check_tool cgpt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,7 +137,7 @@ else
 		if [ "$sure" != "yes" ]; then
 			stop "Stopped by the user"
 		fi
-		tar xJf rootfs.tar.xz -C / lib/modules/
+		tar xJf rootfs.tar.xz -C / usr/lib/modules/
 		dd if=kernel_emmc_ext4.bin of=/dev/mmcblk0p1
 	else
 		check_tool cgpt


### PR DESCRIPTION
The usrmerge project moved `/lib/modules` to `/usr/lib/modules` in Debian Bookworm, including the `rootfs.tar.xz` built for Bookworm systems. As such, `install.sh` fails to extract the kernel files from the archive and cannot upgrade existing Bookworm systems.

This pull request updates the install script to extract kernel files from the correct location. `build.sh` will undo this for Bullseye releases.